### PR TITLE
Fix "any" tutorial & Rewrite examples without quotes

### DIFF
--- a/docs/definitions/intermediate-tutorial/state-stores/producer-user-events.yaml
+++ b/docs/definitions/intermediate-tutorial/state-stores/producer-user-events.yaml
@@ -38,7 +38,7 @@ functions:
         event["price"] = round(random.uniform(50, 2000), 2)
       
       return (user_id, event)
-    resultType: "(string, json)"
+    resultType: (string, json)
 
 producers:
   user_event_generator:

--- a/docs/definitions/reference/data-types/any-processor.yaml
+++ b/docs/definitions/reference/data-types/any-processor.yaml
@@ -1,82 +1,48 @@
-# Demonstrates 'any' type usage in KSML functions
-# 
-# This example shows how to use the 'any' or '?' type in function signatures when
-# processing variable data types. The 'any' type allows functions to accept any
-# type of input and perform generic operations.
+# Simple demonstration of 'any' type processing
+
 streams:
-  mixed_data:
-    topic: mixed_data
+  any_input:
+    topic: any_data
     keyType: string
-    valueType: json  # Input stream with variable JSON structures
-  
-  processed_data:
-    topic: processed_data
+    valueType: json
+
+  any_output:
+    topic: processed_any_data
     keyType: string
-    valueType: json  # Output processed data
+    valueType: json
 
 functions:
-  process_any_data:
+  # Helper function with 'any' parameter type
+  process_data:
+    type: generic
+    parameters:
+      - name: data
+        type: any  # Accepts any type
+    code: |
+      return {
+        "processed_data": data,
+        "status": "processed"
+      }
+    resultType: json
+
+  # Function that uses the helper
+  process_any:
     type: valueTransformer
     code: |
-      # This function demonstrates processing data of unknown/variable types
-      # The 'any' type allows us to accept any input and handle it generically
-      
-      # Since we're dealing with JSON, value will be a dict
-      if isinstance(value, dict):
-        # Add processing metadata regardless of original structure
-        processed = {
-          "original_data": value,
-          "processing_time": time.time(),
-          "processed_by": "any_type_processor"
-        }
-        
-        # Add specific handling based on data type field if present
-        if "type" in value:
-          data_type = value["type"]
-          if data_type == "user_action":
-            processed["category"] = "user_events"
-          elif data_type == "order":
-            processed["category"] = "business_events"
-          elif data_type == "metric":
-            processed["category"] = "system_metrics"
-          else:
-            processed["category"] = "unknown"
-        else:
-          processed["category"] = "untyped_data"
-        
-        log.info(f"Processed {processed.get('category', 'unknown')} data for key: {key}")
-        return processed
-      else:
-        # Handle non-dict values
-        return {
-          "original_data": value,
-          "processing_time": time.time(),
-          "processed_by": "any_type_processor",
-          "category": "non_dict_data",
-          "data_type": str(type(value).__name__)
-        }
-    
-    # Function parameter uses 'any' type to accept variable input
-    # Alternative syntax: parameterType: "?" 
-    parameterType: "any"
-    resultType: "json"
-    globalCode: |
-      import time
+      # Use helper function that accepts 'any' type
+      return process_data(value)
+
+    resultType: json
 
 pipelines:
-  process_mixed_data:
-    from: mixed_data
+  process_data:
+    from: any_input
     via:
-      # Transform values using the any-type function
       - type: transformValue
-        mapper: process_any_data
-      
-      # Log the results
+        mapper: process_any
       - type: peek
         forEach:
           code: |
-            category = value.get("category", "unknown")
-            original_type = value.get("original_data", {}).get("type", "unknown")
-            log.info(f"Processed {category} data (original: {original_type}) for user: {key}")
-    
-    to: processed_data
+            log.info("Processed any type: {} = {}",
+                     value.get("input_type"), value.get("input_value"))
+    to: any_output

--- a/docs/definitions/reference/data-types/any-producer.yaml
+++ b/docs/definitions/reference/data-types/any-producer.yaml
@@ -1,67 +1,40 @@
-# Demonstrates 'any' type usage in KSML functions
-# 
-# This example shows how to use the 'any' or '?' type in function signatures when
-# the exact type is variable or unknown. The 'any' type can only be used within
-# functions for internal processing - streams must still use concrete types.
+# Simple demonstration of 'any' and '?' types in KSML
+
 streams:
-  mixed_data:
-    topic: mixed_data
+  any_data:
+    topic: any_data
     keyType: string
-    valueType: json  # Output as JSON for Kafka serialization
+    valueType: json
 
 functions:
-  generate_mixed_data:
+  generate_data:
     type: generator
-    globalCode: |
-      import random
-      import time
-      
-      # Counter for different data patterns
-      counter = 0
     code: |
-      global counter
-      counter += 1
-      
-      # Generate different types of data
-      user_id = f"user_{counter % 5 + 1}"
-      
-      # Create different JSON structures to demonstrate variable data
-      if counter % 3 == 0:
-        # Simple user event
-        data = {
-          "type": "user_action",
-          "action": "login",
-          "timestamp": int(time.time())
-        }
-      elif counter % 3 == 1:
-        # Complex order data
-        data = {
-          "type": "order",
-          "order_id": f"order_{counter}",
-          "items": [
-            {"product": "laptop", "price": 999.99},
-            {"product": "mouse", "price": 29.99}
-          ],
-          "total": 1029.98
-        }
-      else:
-        # Simple metric
-        data = {
-          "type": "metric",
-          "name": "cpu_usage",
-          "value": random.uniform(0.1, 0.9)
-        }
-      
-      return (user_id, data)
-    
-    # Function can use 'any' type to handle variable internal data
-    # but must return concrete types for stream serialization
-    resultType: "(string, json)"
+      import random
 
-pipelines:
-  generate_mixed_events:
-    from:
-      type: generator
-      function: generate_mixed_data
-      interval: 2s
-    to: mixed_data
+      # Generate different JSON-compatible data structures
+      if random.choice([True, False]):
+        data = {"type": "text", "value": "hello world"}
+      else:
+        data = {"type": "number", "value": 42}
+
+      return ("key1", data)
+
+    resultType: (string, json)
+
+  # Function with '?' parameter type
+  describe_data:
+    type: generic
+    parameters:
+      - name: value
+        type: "?"  # Accepts any type
+    code: |
+      return "processed"
+
+    resultType: string
+
+producers:
+  test_producer:
+    generator: generate_data
+    interval: 2s
+    to: any_data

--- a/docs/definitions/reference/data-types/auto-conversion-producer.yaml
+++ b/docs/definitions/reference/data-types/auto-conversion-producer.yaml
@@ -28,7 +28,7 @@ functions:
       }
       
       return (data["sensor_id"], data)
-    resultType: "(string, json)"
+    resultType: (string, json)
 
 producers:
   sensor_generator:

--- a/docs/definitions/reference/data-types/enum-processor.yaml
+++ b/docs/definitions/reference/data-types/enum-processor.yaml
@@ -10,7 +10,7 @@ streams:
   order_status_stream:
     topic: order_statuses
     keyType: string
-    valueType: "enum(PENDING, PROCESSING, SHIPPED, DELIVERED, CANCELLED)"
+    valueType: enum(PENDING, PROCESSING, SHIPPED, DELIVERED, CANCELLED)
 
 functions:
   extract_and_validate_status:

--- a/docs/definitions/reference/data-types/explicit-conversion-producer.yaml
+++ b/docs/definitions/reference/data-types/explicit-conversion-producer.yaml
@@ -30,7 +30,7 @@ functions:
       }
       
       return (sensor_data["sensor_id"], sensor_data)
-    resultType: "(string, json)"
+    resultType: (string, json)
 
 producers:
   json_generator:

--- a/docs/definitions/reference/data-types/map-processor.yaml
+++ b/docs/definitions/reference/data-types/map-processor.yaml
@@ -4,27 +4,27 @@ streams:
   user_preferences:
     topic: user_preferences
     keyType: string
-    valueType: "map(string)"  # Map with string keys and string values
+    valueType: map(string)  # Map with string keys and string values
 
   user_scores:
     topic: user_scores
     keyType: string
-    valueType: "map(int)"     # Map with string keys and integer values
+    valueType: map(int)     # Map with string keys and integer values
     
   processed_preferences:
     topic: processed_preferences
     keyType: string
-    valueType: "map(string)"  # Output also as map(string)
+    valueType: map(string)  # Output also as map(string)
     
   processed_scores:
     topic: processed_scores
     keyType: string
-    valueType: "map(int)"     # Output also as map(int)
+    valueType: map(int)     # Output also as map(int)
 
 functions:
   enhance_preferences:
     type: valueTransformer
-    resultType: "map(string)"  # Function returns map(string)
+    resultType: map(string)  # Function returns map(string)
     code: |
       # Add a status field to the preferences map
       enhanced = dict(value)  # Copy input map
@@ -33,7 +33,7 @@ functions:
 
   calculate_stats:
     type: valueTransformer
-    resultType: "map(int)"     # Function returns map(int)  
+    resultType: map(int)     # Function returns map(int)  
     code: |
       # Calculate some statistics from scores map
       scores = dict(value)  # Copy input map

--- a/docs/definitions/reference/data-types/map-producer.yaml
+++ b/docs/definitions/reference/data-types/map-producer.yaml
@@ -3,7 +3,7 @@
 functions:
   generate_preferences:
     type: generator
-    resultType: "(string, map(string))"  # Returns a map with string values
+    resultType: (string, map(string))  # Returns a map with string values
     globalCode: |
       import random
       import time
@@ -20,7 +20,7 @@ functions:
 
   generate_scores:
     type: generator
-    resultType: "(string, map(int))"  # Returns a map with integer values
+    resultType: (string, map(int))  # Returns a map with integer values
     globalCode: |
       import random
     code: |
@@ -38,12 +38,12 @@ streams:
   user_preferences:
     topic: user_preferences
     keyType: string
-    valueType: "map(string)"  # Map with string keys and string values
+    valueType: map(string)  # Map with string keys and string values
 
   user_scores:
     topic: user_scores
     keyType: string
-    valueType: "map(int)"     # Map with string keys and integer values
+    valueType: map(int)     # Map with string keys and integer values
 
 producers:
   preferences_producer:

--- a/docs/definitions/reference/data-types/multi-conversion-producer.yaml
+++ b/docs/definitions/reference/data-types/multi-conversion-producer.yaml
@@ -28,7 +28,7 @@ functions:
       }
       
       return (f"item_{counter}", data)
-    resultType: "(string, json)"
+    resultType: (string, json)
 
 producers:
   data_generator:

--- a/docs/definitions/reference/data-types/union-processor.yaml
+++ b/docs/definitions/reference/data-types/union-processor.yaml
@@ -3,7 +3,7 @@ streams:
   optional_messages:
     topic: optional_messages
     keyType: string
-    valueType: "union(null, json)"  # Input as union type
+    valueType: union(null, json)  # Input as union type
   
   processed_messages:
     topic: processed_messages

--- a/docs/definitions/reference/data-types/union-producer.yaml
+++ b/docs/definitions/reference/data-types/union-producer.yaml
@@ -30,7 +30,7 @@ functions:
         return (key, message)
     code: |
       return get_optional_message()
-    resultType: "(string, union(null, json))"  # Function returns union type
+    resultType: (string, union(null, json))  # Function returns union type
 
 producers:
   optional_producer:

--- a/docs/definitions/reference/data-types/windowed-processor-notation.yaml
+++ b/docs/definitions/reference/data-types/windowed-processor-notation.yaml
@@ -11,7 +11,7 @@
 #
 # Example: 
 #   - type: convertKey
-#     into: "json:windowed(string)"  # Automatically serializes as JSON structure
+#     into: json:windowed(string)  # Automatically serializes as JSON structure
 #
 # Without notation, windowed keys cannot be serialized to Kafka topics and require manual
 # transformation to regular types.
@@ -57,7 +57,7 @@ pipelines:
       # Using json:windowed(string) automatically serializes windowed keys as JSON structures
       # containing: start, end, startTime, endTime, and key fields
       - type: convertKey
-        into: "json:windowed(string)"  # Recommended: use notation prefix for automatic serialization
+        into: json:windowed(string)  # Recommended: use notation prefix for automatic serialization
       
       # Log the windowed counts
       - type: peek

--- a/docs/definitions/reference/data-types/windowed-processor.yaml
+++ b/docs/definitions/reference/data-types/windowed-processor.yaml
@@ -49,7 +49,7 @@ pipelines:
       # Explicitly convert the key to windowed(string) type
       # This shows how KSML handles windowed keys internally
       - type: convertKey
-        into: "windowed(string)"
+        into: windowed(string)
       
       # Log the windowed counts with the windowed key type
       - type: peek
@@ -62,7 +62,7 @@ pipelines:
       # This is necessary because Kafka topics cannot serialize windowed keys
       - type: transformKeyValue
         mapper:
-          resultType: "(string, json)"
+          resultType: (string, json)
           code: |
             # Extract window information from the windowed key
             # Convert to a string key format: "user_startTime_endTime"

--- a/docs/definitions/reference/functions/keyvaluetokeyvaluelisttransformer-processor.yaml
+++ b/docs/definitions/reference/functions/keyvaluetokeyvaluelisttransformer-processor.yaml
@@ -39,7 +39,7 @@ functions:
       
       log.info("Split batch {} into {} individual orders", batch_id, len(individual_records))
       return individual_records
-    resultType: "[(string, json)]"
+    resultType: list(tuple(string, json))
 
 pipelines:
   split_batch_processing:

--- a/docs/definitions/reference/functions/keyvaluetovaluelisttransformer-processor.yaml
+++ b/docs/definitions/reference/functions/keyvaluetovaluelisttransformer-processor.yaml
@@ -37,7 +37,7 @@ functions:
                value.get("order_id"), len(item_records))
       
       return item_records
-    resultType: "[json]"
+    resultType: list(json)
 
 pipelines:
   explode_orders:

--- a/docs/definitions/reference/operations/flatmap-processor.yaml
+++ b/docs/definitions/reference/operations/flatmap-processor.yaml
@@ -10,7 +10,7 @@ pipelines:
     via:
       - type: flatMap
         mapper:
-          resultType: "[(string,json)]"
+          resultType: list(tuple(string, json))
           code: |
             return [(f"{value['order_id']}_{i['item_id']}", {
               "order_id": value['order_id'],

--- a/docs/definitions/reference/table-store-processor.yaml
+++ b/docs/definitions/reference/table-store-processor.yaml
@@ -66,7 +66,7 @@ producers:
       valueType: json
     generator:
       type: generator
-      resultType: "(string, json)"
+      resultType: (string, json)
       code: |
         import random
         import time

--- a/docs/definitions/reference/table-store-producer.yaml
+++ b/docs/definitions/reference/table-store-producer.yaml
@@ -7,7 +7,7 @@ streams:
 functions:
   generate_user_profile:
     type: generator
-    resultType: "(string, json)"
+    resultType: (string, json)
     code: |
       import random
       import time

--- a/docs/definitions/use-cases/event-driven-applications/inventory-event-processors.yaml
+++ b/docs/definitions/use-cases/event-driven-applications/inventory-event-processors.yaml
@@ -46,7 +46,7 @@ pipelines:
               if product_id:
                 result.append((product_id, {**item, "order_id":key}))
             return result
-          resultType: "[(string, struct)]"
+          resultType: list(tuple(string, struct))
       - type: peek
         forEach:
           code: |


### PR DESCRIPTION
1. Fix "any" tutorial
2. Remove quotes from examples' resultType, valueType, keyType